### PR TITLE
Fix typo and fix URL to guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,10 +341,10 @@
             <p class="caption secondary"><sup>3</sup> Cellular support is still unfinished and might be broken in some
                 areas. Cellular calls are automatically enabled in up to Windows 10 November 2019 Update (version 19H2, build
                 18363). Versions higher than this will <strong>only</strong> support cellular data. You can manually enable 
-                calls on builds higher than 18363 by using [this guide]. SMS are supported up to Windows 10 November 2019 Update 
+                calls on builds higher than 18363 by using <a href="https://woa-project.github.io/LumiaWOA/guides/ican0/">this guide</a>. SMS are supported up to Windows 10 November 2019 Update 
                 (version 19H2, build 18363). Dual SIM devices may have issues fetching the default Carrier APN settings, a provisioning 
                 package for APN may be required. The advanced settings page for Cellular in the Windows Settings app may crash. 
-                Your experience will vary between carries and devices. This software stack has not been approved for use with emergency services.
+                Your experience will vary between carriers and devices. This software stack has not been approved for use with emergency services.
                 As a consequence <strong>it should not be used as your primary way of communication</strong>. VoLTE (IMS) stack while
                 present is not functional.</p>
         </div>


### PR DESCRIPTION
Someone in the LumiaWOA Telegram group pointed out a typo on the website. While fixing it, I also found something that seems to be meant as link, but which was not.

This PR fixes the typo and adds a link to the guide that is mentioned in the text.